### PR TITLE
Add missing tags file

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,7 @@
+:IcontractHypothesisInspect	icontract_hypothesis.txt	/*:IcontractHypothesisInspect*
+:IcontractHypothesisTest	icontract_hypothesis.txt	/*:IcontractHypothesisTest*
+icontract-hypothesis-changelog	icontract_hypothesis.txt	/*icontract-hypothesis-changelog*
+icontract-hypothesis-installation	icontract_hypothesis.txt	/*icontract-hypothesis-installation*
+icontract-hypothesis-usage	icontract_hypothesis.txt	/*icontract-hypothesis-usage*
+icontract-hypothesis-versioning	icontract_hypothesis.txt	/*icontract-hypothesis-versioning*
+icontract_hypothesis.txt	icontract_hypothesis.txt	/*icontract_hypothesis.txt*


### PR DESCRIPTION
With the current version, after installing this plugin as a submodule, a tag file is automatically generated when a file is opened in Vim. 

However, it creates an annoying error when it keeps requiring to stage that tags file.

And since it is a submodule, I cannot push that tags file to GitHub. 

So I generate a tags file and add it to the current plugin so that no new tags file is generated which solves the problem.